### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,37 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+      - name: Gzip static files
+        run: "for file in gzstatic/*; do gzip $file; done"
+      - name: Create release zip
+        run: "zip openjbod.zip -r * -x README.md LICENSE.md @"
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload asset
+        id: upload-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./openjbod.zip
+          asset_name: openjbod.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Add a release action that gzip's the static files, creates a release and uploads the resulting zip without unnecessary files to GitHub for easy distribution.