### PR TITLE
Rework the Actions CI

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -6,10 +6,10 @@ on:
     tags:
       - 'v*'
 
-name: Create Release
+name: Build MicroPython and Release
 jobs:
   build:
-    name: Create Release
+    name: Build and Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout micropython
@@ -60,6 +60,9 @@ jobs:
 
       - name: Freeze OpenJBOD Software
         run: python3 -m freezefs software/ micropython/ports/rp2/boards/OPENJBOD_RP2040/frozen_openjbod.py --on-import=extract --compress -t / -ov always
+
+      - name: Copy _boot.py to MicroPython
+        run: cp software/_boot.py micropython/ports/rp2/modules/_boot.py
 
       - name: Build mpy-cross
         run: make -j $(nproc) -C micropython/mpy-cross/

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,5 +1,8 @@
 on:
+  pull_request:
   push:
+    branches:
+      - '**'
     tags:
       - 'v*'
 
@@ -9,15 +12,74 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout micropython
         uses: actions/checkout@main
+        with:
+          repository: 'micropython/micropython'
+          ref: 'v1.23.0'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: 'true'
+          path: 'micropython'
+
+      - name: Checkout OpenJBOD board definitions
+        uses: actions/checkout@main
+        with:
+          repository: 'openjbod/micropython'
+          path: 'openjbod'
+
+      - name: Checkout OpenJBOD software
+        uses: actions/checkout@main
+        with:
+          path: 'software'
+
+      - name: Install build tools
+        run: sudo apt-get install pkg-config gcc-arm-none-eabi libnewlib-arm-none-eabi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Copy board definitions to MicroPython
+        run: cp -r openjbod/boards/OPENJBOD_RP2040 micropython/ports/rp2/boards/
+
+      - name: Install Python requirements
+        run: "pip install freezefs"
+
       - name: Gzip static files
-        run: "for file in gzstatic/*; do gzip $file; done"
+        run: "for file in software/gzstatic/*; do gzip $file; done"
+
       - name: Create release zip
-        run: "zip openjbod.zip -r * -x README.md LICENSE.md @"
+        run: "zip openjbod.zip -r software/* -x README.md LICENSE.md @"
+
+      - name: Upload release zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: openjbod
+          path: ./software
+
+      - name: Freeze OpenJBOD Software
+        run: python3 -m freezefs software/ micropython/ports/rp2/boards/OPENJBOD_RP2040/frozen_openjbod.py --on-import=extract --compress -t / -ov always
+
+      - name: Build mpy-cross
+        run: make -j $(nproc) -C micropython/mpy-cross/
+
+      - name: Fetch MicroPython submodules
+        run: make -j $(nproc) -C micropython/ports/rp2 BOARD=OPENJBOD_RP2040 submodules
+
+      - name: Build MicroPython
+        run: make -j $(nproc) -C micropython/ports/rp2 BOARD=OPENJBOD_RP2040
+
+      - name: Upload MicroPython artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openjbod-firmware
+          path: micropython/ports/rp2/build-OPENJBOD_RP2040/firmware.uf2
+
       - name: Create release
         id: create_release
         uses: actions/create-release@latest
+        if: ${{ (github.event_name == 'push') && (startsWith(github.ref, 'refs/targs/v')) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -25,9 +87,11 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+
       - name: Upload asset
         id: upload-asset
         uses: actions/upload-release-asset@v1
+        if: ${{ (github.event_name == 'push') && (startsWith(github.ref, 'refs/targs/v')) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Copy board definitions to MicroPython
         run: cp -r openjbod/boards/OPENJBOD_RP2040 micropython/ports/rp2/boards/
 
+      - name: Copy _boot.py to MicroPython
+        run: cp openjbod/_boot.py micropython/ports/rp2/modules/_boot.py
+
       - name: Install Python requirements
         run: "pip install freezefs"
 
@@ -60,9 +63,6 @@ jobs:
 
       - name: Freeze OpenJBOD Software
         run: python3 -m freezefs software/ micropython/ports/rp2/boards/OPENJBOD_RP2040/frozen_openjbod.py --on-import=extract --compress -t / -ov always
-
-      - name: Copy _boot.py to MicroPython
-        run: cp software/_boot.py micropython/ports/rp2/modules/_boot.py
 
       - name: Build mpy-cross
         run: make -j $(nproc) -C micropython/mpy-cross/


### PR DESCRIPTION
The new actions run still "build" the software into a zip package that can be uploaded to an OpenJBOD RP2040 board, however it will also build MicroPython with OpenJBOD built in via freezefs. This simplifies deploying and updating the firmware significantly.

Breaking down how this works:

The OpenJBOD software is cloned into the directory at build-time and forzen into a single python file using freezefs. The file will automatically extract itself to `/` on execution, unpacking all the necessary files.
The frozen package is imported by the _boot.py script that runs when MicroPython is first initialized. This means the files are overwritten on every boot. Note that config.json is excluded from this.